### PR TITLE
Quick sketch of adding an apt repo and key

### DIFF
--- a/core/src/main/resources/org/scalawag/jibe/backend/ubuntu/InstallAptKey.sh
+++ b/core/src/main/resources/org/scalawag/jibe/backend/ubuntu/InstallAptKey.sh
@@ -1,0 +1,2 @@
+PATH=/usr/bin:/bin
+apt-key adv --keyserver "$keyserver" --recv-keys "$fingerprint"

--- a/core/src/main/resources/org/scalawag/jibe/backend/ubuntu/IsAptKeyInstalled.sh
+++ b/core/src/main/resources/org/scalawag/jibe/backend/ubuntu/IsAptKeyInstalled.sh
@@ -1,0 +1,3 @@
+PATH=/usr/bin:/bin
+set -o pipefail
+apt-key finger | grep fingerprint | sed -e 's/.* = //' -e 's/ //g' | grep "$fingerprint"

--- a/core/src/main/scala/org/scalawag/jibe/mandate/PackageMandates.scala
+++ b/core/src/main/scala/org/scalawag/jibe/mandate/PackageMandates.scala
@@ -12,7 +12,6 @@ object Package {
   def apply(name: String, version: String): Package = new Package(name, Some(version))
 }
 
-@CommandArgument
 case class InstallPackage(pkg: Package) extends StatelessMandate with MandateHelpers {
   override val description = Some(s"install package: ${pkg.name}" )
 
@@ -27,4 +26,14 @@ case class InstallPackage(pkg: Package) extends StatelessMandate with MandateHel
     runCommand(command.UpdateAptGet(1.day))
     runCommand(command.InstallPackage(pkg))
   }
+}
+
+case class InstallAptKey(keyserver: String, fingerprint: String) extends StatelessMandate with MandateHelpers {
+  override val description = Some(s"install apt key: ${fingerprint}" )
+
+  override def isActionCompleted(implicit context: MandateExecutionContext) =
+    runCommand(command.IsAptKeyInstalled(fingerprint))
+
+  override def takeAction(implicit context: MandateExecutionContext) =
+    runCommand(command.InstallAptKey(keyserver, fingerprint))
 }

--- a/core/src/main/scala/org/scalawag/jibe/mandate/command/PackageCommands.scala
+++ b/core/src/main/scala/org/scalawag/jibe/mandate/command/PackageCommands.scala
@@ -21,3 +21,10 @@ case class InstallPackage(pkg: Package) extends UnitCommand
 
 @CommandArgument
 case class UpdateAptGet(refreshInterval: Duration) extends UnitCommand
+
+@CommandArgument
+case class IsAptKeyInstalled(fingerprint: String) extends BooleanCommand
+
+@CommandArgument
+case class InstallAptKey(keyserver: String, fingerprint: String) extends UnitCommand
+


### PR DESCRIPTION
@dwcramer 

This isn't necessarily worth merging as-is because there are several problems with it, but it's a first-pass at getting the functionality that I want.  Some obvious things needed:
- Some idea of how to make `apt-get update` only run when the prior two mandates change the state of the system.
- A better way to manage the apt sources.list other than "push this file."
- Failure from `apt-key finger` should cause an error and not look the same as the key missing (when grep can't find it).
- Tests. :)
